### PR TITLE
Fix assert never

### DIFF
--- a/src/lib/assert-never.ts
+++ b/src/lib/assert-never.ts
@@ -1,3 +1,4 @@
+// Used for exhaustiveness checking
 export default function assertNever(value: never): never {
-  throw new Error(`value {value} has reached assertNever`);
+  throw new Error(`value ${value} has reached assertNever`);
 }


### PR DESCRIPTION
Assert-never is a nice trick in typescript with switch-cases and union types. When used correctly it ensures that all cases are handled.